### PR TITLE
Create initial 'Curator' app components

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/node_modules
+**/npm_debug.log
+**/public/dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@
 
 # Generated Protobufs
 **/protobuf/
+
+# Node
+**/node_modules
+**/package-lock.json
+**/npm-debug.log
+**/v8-compile-cache-0
+
+# Webpack
+**/dist

--- a/curator_app/Dockerfile
+++ b/curator_app/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+FROM httpd:2.4
+
+ENV PATH $PATH:/project/sawtooth-simple-supply/bin
+
+RUN echo "\
+\n\
+ServerName curator_app\n\
+AddDefaultCharset utf-8\n\
+LoadModule proxy_module modules/mod_proxy.so\n\
+LoadModule proxy_http_module modules/mod_proxy_http.so\n\
+ProxyPass /api http://simple-supply-rest-api:8000\n\
+ProxyPassReverse /api http://simple-supply-rest-api:8000\n\
+\n\
+" >>/usr/local/apache2/conf/httpd.conf
+
+EXPOSE 80/tcp

--- a/curator_app/package.json
+++ b/curator_app/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "curator_app",
+  "version": "1.0.0",
+  "description": "A Sawtooth Simple Supply client web app for tracking works of art",
+  "main": "",
+  "scripts": {
+    "watch": "webpack-dev-server --env development --hot",
+    "build": "webpack --env production"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/hyperledger/education-sawtooth-simple-supply#readme",
+  "dependencies": {
+    "bootstrap": "^4.1.1",
+    "jquery": "^3.3.1",
+    "mithril": "^1.1.6",
+    "octicons": "^6.0.1",
+    "popper.js": "^1.14.3"
+  },
+  "devDependencies": {
+    "autoprefixer": "^8.6.2",
+    "css-loader": "^0.28.11",
+    "node-sass": "^4.9.0",
+    "postcss-loader": "^2.1.5",
+    "precss": "^3.1.2",
+    "sass-loader": "^7.0.3",
+    "style-loader": "^0.21.0",
+    "webpack": "^4.12.0",
+    "webpack-cli": "^3.0.4",
+    "webpack-dev-server": "^3.1.4"
+  }
+}

--- a/curator_app/public/index.html
+++ b/curator_app/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Curator</title>
+  </head>
+  <body>
+    <!-- mount point for the Mithril JS app -->
+    <div id="app"></div>
+
+    <script src="dist/bundle.js"></script>
+  </body>
+</html>

--- a/curator_app/src/components/navigation.js
+++ b/curator_app/src/components/navigation.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+
+/**
+ * A simple navbar wrapper, which displays children in the responsive collapse.
+ */
+const Navbar = {
+  view (vnode) {
+    return m('nav.navbar.navbar-expand-sm.navbar-dark.bg-primary.mb-5', [
+      m('a.navbar-brand[href="/"]', {
+        oncreate: m.route.link
+      }, 'Curator'),
+      m('button.navbar-toggler', {
+        type: 'button',
+        'data-toggle': 'collapse',
+        'data-target': '#navbar',
+        'aria-controls': 'navbar',
+        'aria-expanded': 'false',
+        'aria-label': 'Toggle navigation'
+      }, m('span.navbar-toggler-icon')),
+      m('#navbar.collapse.navbar-collapse', vnode.children)
+    ])
+  }
+}
+
+/**
+ * Creates a list of left-aligned navbar links from href/label tuples.
+ */
+const links = items => {
+  return m('ul.navbar-nav.mr-auto', items.map(([href, label]) => {
+    return m('li.nav-item', [
+      m('a.nav-link', { href, oncreate: m.route.link }, label)
+    ])
+  }))
+}
+
+/**
+ * Creates a single link for use in a navbar.
+ */
+const link = (href, label) => {
+  return m('.navbar-nav', [
+    m('a.nav-link', { href, oncreate: m.route.link }, label)
+  ])
+}
+
+/**
+ * Creates a navigation button styled for use in the navbar.
+ */
+const button = (href, label) => {
+  return m('a.btn.btn-outline-light.my-2.my-sm-0', {
+    href,
+    oncreate: m.route.link
+  }, label)
+}
+
+module.exports = {
+  Navbar,
+  link,
+  links,
+  button
+}

--- a/curator_app/src/main.js
+++ b/curator_app/src/main.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+// These requires inform webpack which styles to build
+require('bootstrap')
+require('../styles/main.scss')
+
+const m = require('mithril')
+
+const api = require('./services/api')
+const navigation = require('./components/navigation')
+
+const AgentList = require('./views/agent_list')
+const RegisterArtworkForm = require('./views/register_artwork_form')
+const Dashboard = require('./views/dashboard')
+const LoginForm = require('./views/login_form')
+const ArtworkList = require('./views/artwork_list')
+const SignupForm = require('./views/signup_form')
+
+/**
+ * A basic layout component that adds the navbar to the view.
+ */
+const Layout = {
+  view (vnode) {
+    return [
+      vnode.attrs.navbar,
+      m('.content.container', vnode.children)
+    ]
+  }
+}
+
+const loggedInNav = () => {
+  const links = [
+    ['/register', 'Register Artwork'],
+    ['/artworks', 'View Artwork Registry'],
+    ['/agents', 'View Agents']
+  ]
+  return m(navigation.Navbar, {}, [
+    navigation.links(links),
+    navigation.link('/profile', 'Profile'),
+    navigation.button('/logout', 'Logout')
+  ])
+}
+
+const loggedOutNav = () => {
+  const links = [
+    ['/artworks', 'View Artwork Registry'],
+    ['/agents', 'View Agents']
+  ]
+  return m(navigation.Navbar, {}, [
+    navigation.links(links),
+    navigation.button('/login', 'Log in/Sign up')
+  ])
+}
+
+/**
+ * Returns a route resolver which handles authorization related business.
+ */
+const resolve = (view, restricted = false) => {
+  const resolver = {}
+
+  if (restricted) {
+    resolver.onmatch = () => {
+      if (api.getAuth()) return view
+      m.route.set('/login')
+    }
+  }
+
+  resolver.render = vnode => {
+    if (api.getAuth()) {
+      return m(Layout, { navbar: loggedInNav() }, m(view, vnode.attrs))
+    }
+    return m(Layout, { navbar: loggedOutNav() }, m(view, vnode.attrs))
+  }
+
+  return resolver
+}
+
+/**
+ * Clears user info from memory/storage and redirects.
+ */
+const logout = () => {
+  m.route.set('/')
+}
+
+/**
+ * Redirects to user's personal account page if logged in.
+ */
+const profile = () => {
+  m.route.set('/')
+}
+
+/**
+ * Build and mount app/router
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  m.route(document.querySelector('#app'), '/', {
+    '/': resolve(Dashboard),
+    '/agents': resolve(AgentList),
+    '/register': resolve(RegisterArtworkForm, true),
+    '/login': resolve(LoginForm),
+    '/logout': { onmatch: logout },
+    '/profile': { onmatch: profile},
+    '/artworks': resolve(ArtworkList),
+    '/signup': resolve(SignupForm)
+  })
+})

--- a/curator_app/src/services/api.js
+++ b/curator_app/src/services/api.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+
+const STORAGE_KEY = 'curator.authorization'
+let authToken = null
+
+/**
+ * Getters and setters to handle the auth token both in memory and storage
+ */
+const getAuth = () => {
+  if (!authToken) {
+    authToken = window.localStorage.getItem(STORAGE_KEY)
+  }
+  return authToken
+}
+
+module.exports = {
+  getAuth
+}

--- a/curator_app/src/views/agent_list.js
+++ b/curator_app/src/views/agent_list.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+
+const AgentList = {
+  view (vnode) {
+    return [
+      m('.header.text-center.mb-2',
+        m('h4', 'Agent List Placeholder'))
+    ]
+  }
+}
+
+module.exports = AgentList

--- a/curator_app/src/views/artwork_list.js
+++ b/curator_app/src/views/artwork_list.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+
+const ArtworkList = {
+  view (vnode) {
+    return [
+      m('.header.text-center.mb-2',
+        m('h4', 'Artwork Registry Placeholder'))
+    ]
+  }
+}
+
+module.exports = ArtworkList

--- a/curator_app/src/views/dashboard.js
+++ b/curator_app/src/views/dashboard.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+
+'use strict'
+
+const m = require('mithril')
+
+const Dashboard = {
+  view(vnode) {
+    return [
+      m('.header.text-center.mb-4',
+        m('h4', 'Welcome To'),
+        m('h1.mb-3', 'Curator'),
+        m('h5',
+          m('em',
+            'Powered by ',
+            m('strong', 'Sawtooth Simple Supply')))),
+      m('.blurb',
+        m('p',
+          m('em', 'Sawtooth Simple Supply'),
+          ' is a simple, general-purpose supply chain application built',
+          ' using the Hyperledger Sawtooth blockchain platform. It maintains',
+          ' a distributed ledger that records the provenance and location',
+          ' of assets as they are transferred among various agents in a',
+          ' supply chain.'),
+        m('p',
+          m('em', 'Curator'),
+          ' demonstrates this functionality with an example web app for',
+          ' artwork loans. It tracks the provenance and location of works of',
+          ' art as they are transported to and from different museums or ',
+          ' collectors.'),
+        m('p',
+          'To use ',
+          m('em', 'Curator'),
+          ', create a new agent using the Log in/Sign up link on the navbar',
+          ' above. Once logged in, you will be able to register a work of',
+          ' art on the blockchain, update its location, and transfer',
+          ' ownership of the work of art to other registered agents.'))
+    ]
+  }
+}
+
+module.exports = Dashboard

--- a/curator_app/src/views/login_form.js
+++ b/curator_app/src/views/login_form.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+
+'use strict'
+
+const m = require('mithril')
+
+/**
+ * The Form for authorizing an existing user.
+ */
+const LoginForm = {
+  view (vnode) {
+    return [
+      m('.header.text-center.mb-2',
+        m('h4', 'Login Form Placeholder'))
+    ]
+  }
+}
+
+module.exports = LoginForm

--- a/curator_app/src/views/register_artwork_form.js
+++ b/curator_app/src/views/register_artwork_form.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+
+'use strict'
+
+const m = require('mithril')
+
+const RegisterArtworkForm = {
+  view (vnode) {
+    return [
+      m('.header.text-center.mb-2',
+        m('h4', 'Register Artwork Form Placeholder'))
+    ]
+  }
+}
+
+module.exports = RegisterArtworkForm

--- a/curator_app/src/views/signup_form.js
+++ b/curator_app/src/views/signup_form.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+
+const SignupForm = {
+  view (vnode) {
+    return [
+      m('.header.text-center.mb-2',
+        m('h4', 'Signup Form Placeholder'))
+    ]
+  }
+}
+
+module.exports = SignupForm

--- a/curator_app/styles/main.scss
+++ b/curator_app/styles/main.scss
@@ -1,0 +1,2 @@
+@import "~bootstrap/scss/bootstrap";
+@import "~octicons/build/octicons.min";

--- a/curator_app/webpack.config.js
+++ b/curator_app/webpack.config.js
@@ -1,0 +1,41 @@
+const path = require('path')
+const webpack = require('webpack')
+
+module.exports = {
+  entry: './src/main',
+
+  output: {
+    path: path.resolve(__dirname, 'public/dist'),
+    filename: 'bundle.js'
+  },
+
+  module: {
+    rules: [{
+      test: /\.(scss)$/,
+      use: [{
+        loader: 'style-loader'
+      }, {
+        loader: 'css-loader'
+      }, {
+        loader: 'postcss-loader',
+        options: {
+          plugins: () => [
+            require('precss'),
+            require('autoprefixer')
+          ]
+        }
+      }, {
+        loader: 'sass-loader'
+      }]
+    }]
+  },
+
+  plugins: [
+    new webpack.ProvidePlugin({
+      $: 'jquery',
+      jQuery: 'jquery',
+      'window.jQuery': 'jquery',
+      Popper: ['popper.js', 'default']
+    })
+  ]
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,9 +25,13 @@ services:
     container_name: simple-supply-shell
     volumes:
       - .:/project/sawtooth-simple-supply
+      - /project/sawtooth-simple-supply/curator_app/node_modules
     command: |
       bash -c "
         simple-supply-protogen
+        cd curator_app/
+        npm run build
+        cd ../
         tail -f /dev/null
       "
 
@@ -147,3 +151,17 @@ services:
     restart: always
     ports:
       - '8080:8080'
+
+  curator-app:
+    build: ./curator_app
+    image: simple-supply-curator-app
+    container_name: curator-app
+    volumes:
+      - ./curator_app/public/:/usr/local/apache2/htdocs/
+    expose:
+      - 80
+    ports:
+      - '8040:80'
+    depends_on:
+      - simple-supply-shell
+      - simple-supply-rest-api

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -20,10 +20,14 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
  && apt-get update
 
 RUN apt-get install -y --allow-unauthenticated -q \
+    curl \
     python3-pip \
     python3-sawtooth-cli \
     python3-sawtooth-sdk \
     python3-sawtooth-rest-api
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+    && apt-get install -y nodejs
 
 RUN pip3 install \
     aiohttp \
@@ -38,5 +42,9 @@ RUN pip3 install \
     pycodestyle
 
 WORKDIR /project/sawtooth-simple-supply
+
+COPY curator_app/package.json /project/sawtooth-simple-supply/curator_app/
+
+RUN cd curator_app/ && npm install
 
 ENV PATH $PATH:/project/sawtooth-simple-supply/bin


### PR DESCRIPTION

Implements the initial components and navigation for the Curator app, built on top of Simple Supply. After running `docker-compose up`, the application can be accessed at `localhost:8040`. Most pages are placeholders.