### PR TITLE
Remove agent database fetch for post route

### DIFF
--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -46,14 +46,12 @@ paths:
             $ref: '#/definitions/NewAgentBody'
       responses:
         '200':
-          description: Success response with the new agent and auth token
+          description: Success response with auth token
           schema:
             type: object
             properties:
               authorization:
                 $ref: '#/definitions/AuthToken'
-              agent:
-                $ref: '#/definitions/AgentObject'
         '400':
           $ref: '#/responses/400BadRequest'
         '500':

--- a/rest_api/simple_supply_rest_api/route_handler.py
+++ b/rest_api/simple_supply_rest_api/route_handler.py
@@ -24,7 +24,6 @@ from itsdangerous import BadSignature
 from itsdangerous import TimedJSONWebSignatureSerializer as Serializer
 
 from simple_supply_rest_api.errors import ApiBadRequest
-from simple_supply_rest_api.errors import ApiInternalError
 from simple_supply_rest_api.errors import ApiNotFound
 from simple_supply_rest_api.errors import ApiUnauthorized
 
@@ -78,18 +77,10 @@ class RouteHandler(object):
         await self._database.create_auth_entry(
             public_key, encrypted_private_key, hashed_password)
 
-        agent = await self._database.fetch_agent_resource(public_key)
-        if agent is None:
-            raise ApiInternalError(
-                'Transaction committed but not yet reported')
-        authorization = generate_auth_token(
+        token = generate_auth_token(
             request.app['secret_key'], public_key)
 
-        response = {
-            'authorization': authorization,
-            'agent': agent
-        }
-        return json_response(response)
+        return json_response({'authorization': token})
 
     async def list_agents(self):
         agent_list = await self._database.fetch_all_agent_resources()


### PR DESCRIPTION
Eliminates a race condition caused by fetching a resource we just issued a transaction to create.
Instead we will just return the auth token.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>