### PR TITLE
Fix apt-key/gpg Proxy Handling

### DIFF
--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -15,7 +15,10 @@
 
 FROM ubuntu:16.04
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+RUN \
+ apt-get update \
+ && apt-get install -y -q curl gnupg \
+ && curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add -  \
  && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
  && apt-get update
 

--- a/rest_api/Dockerfile
+++ b/rest_api/Dockerfile
@@ -15,7 +15,10 @@
 
 FROM ubuntu:16.04
 
-RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD" \
+RUN \
+ apt-get update \
+ && apt-get install -y -q curl gnupg \
+ && curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add -  \
  && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
  && apt-get update
 

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -15,7 +15,10 @@
 
 FROM ubuntu:xenial
 
-RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD" \
+RUN \
+ apt-get update \
+ && apt-get install -y -q curl gnupg \
+ && curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add -  \
  && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
  && apt-get update
 

--- a/subscriber/Dockerfile
+++ b/subscriber/Dockerfile
@@ -15,7 +15,11 @@
 
 FROM ubuntu:16.04
 
-RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD" \
+RUN \
+ echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD" \
+ && apt-get update \
+ && apt-get install -y -q curl gnupg \
+ && curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add -  \
  && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
  && apt-get update
 


### PR DESCRIPTION
gpg (through "apt-key adv") now ignores http_proxy and
https_proxy settings on Bionic.
The solution is to use http with curl instead to download keys.

Remove unused http_proxy and https_proxy initialization.

Signed-off-by: danintel <daniel.anderson@intel.com>