### PR TITLE
Fix Protobuf Error with serialized_options

### DIFF
--- a/bin/simple-supply-fix-protogen
+++ b/bin/simple-supply-fix-protogen
@@ -1,0 +1,27 @@
+#!//bin/sh
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+cd protobuf/simple_supply_protobuf
+for i in *_pb2.py ; do
+    grep -q serialized_options $i
+    if [ $? -eq 0 ] ; then
+        echo "Removing serialized_options from $i"
+        cp $i $i.tmp
+        sed 's/serialized_options=None,//g' <$i.tmp >$i
+        rm $i.tmp
+    fi
+done
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
     command: |
       bash -c "
         simple-supply-protogen
+        simple-supply-fix-protogen
         cd curator_app/
         npm run build
         cd ../


### PR DESCRIPTION
Error was:
TypeError: __new__() got an unexpected keyword argument 'serialized_options'
This requires Protobuf 3.6.0 or above to support serialized_options,
but repo.sawtooth.me is only at Protobuf 3.4.1 for Sawtooth 1.0 and 1.1 at least.

The fix is to remove the unsupported serialized_options argument.

Signed-off-by: danintel <daniel.anderson@intel.com>