### PR TITLE
Fetch GRPCio from Ubuntu repository

### DIFF
--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -19,7 +19,10 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F10
  && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
  && apt-get update
 
-RUN apt-get install -y -q python3-sawtooth-sdk
+RUN apt-get install -y -q python3-sawtooth-sdk \
+    python3-pip
+
+RUN pip3 install grpcio-tools
 
 WORKDIR /project/sawtooth-simple-supply
 

--- a/rest_api/Dockerfile
+++ b/rest_api/Dockerfile
@@ -19,7 +19,8 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
  && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
  && apt-get update
 
-RUN apt-get install -y --allow-unauthenticated -q python3-grpcio-tools=1.1.3-1 \
+RUN apt-get install -y --allow-unauthenticated -q \
+    libffi-dev \
     python3-pip \
     python3-sawtooth-rest-api \
     python3-sawtooth-sdk
@@ -28,6 +29,7 @@ RUN pip3 install \
     aiohttp \
     aiopg \
     bcrypt \
+    grpcio-tools \
     itsdangerous \
     pycrypto \
     psycopg2-binary

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -21,6 +21,7 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
 
 RUN apt-get install -y --allow-unauthenticated -q \
     curl \
+    libffi-dev \
     python3-pip \
     python3-sawtooth-cli \
     python3-sawtooth-sdk \

--- a/subscriber/Dockerfile
+++ b/subscriber/Dockerfile
@@ -19,11 +19,11 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
  && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
  && apt-get update
 
-RUN apt-get install -y --allow-unauthenticated -q \
-    python3-pip \
+RUN apt-get install -y --allow-unauthenticated -q python3-pip \
     python3-sawtooth-sdk
 
 RUN pip3 install \
+    grpcio-tools \
     psycopg2-binary
 
 WORKDIR /project/sawtooth-simple-supply


### PR DESCRIPTION
Related with https://github.com/hyperledger/education-sawtooth-simple-supply/issues/26.

@danintel, I'm using the version from ubuntu repo grpcio-tools==1.21.1, both for generating on shell and reading services.

I'm not sure about the necessity to use the python3-grpcio-tools package from repo.sawtooth.me, but maybe can be a solution to set this package on rest-api, subscriber and processor.