### PR TITLE
Update to Sawtooth 1.2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -96,14 +96,14 @@ services:
       "
 
   settings-tp:
-    image: hyperledger/sawtooth-settings-tp:1.0
+    image: hyperledger/sawtooth-settings-tp:1.2
     container_name: sawtooth-settings-tp
     depends_on:
       - validator
     entrypoint: settings-tp -vv -C tcp://validator:4004
 
   rest-api:
-    image: hyperledger/sawtooth-rest-api:1.0
+    image: hyperledger/sawtooth-rest-api:1.2
     container_name: sawtooth-rest-api
     expose:
       - 8008
@@ -114,7 +114,7 @@ services:
     entrypoint: sawtooth-rest-api -vv -C tcp://validator:4004 --bind rest-api:8008
 
   validator:
-    image: hyperledger/sawtooth-validator:1.0
+    image: hyperledger/sawtooth-validator:1.2
     container_name: sawtooth-validator
     expose:
       - 4004
@@ -131,8 +131,20 @@ services:
         sawtooth-validator -vv \
           --endpoint tcp://validator:8800 \
           --bind component:tcp://eth0:4004 \
-          --bind network:tcp://eth0:8800
+          --bind network:tcp://eth0:8800 \
+          --bind consensus:tcp://eth0:5050
       "
+
+  devmode-engine:
+    image: hyperledger/sawtooth-devmode-engine-rust:1.2
+    expose:
+      - 5050
+    ports:
+      - '5050:5050'
+    container_name: sawtooth-devmode-engine-rust-default
+    depends_on:
+      - validator
+    entrypoint: devmode-engine-rust --connect tcp://validator:5050
 
   postgres:
     image: postgres:alpine

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -13,13 +13,13 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 
-FROM ubuntu:16.04
+FROM ubuntu:bionic
 
 RUN \
  apt-get update \
  && apt-get install -y -q curl gnupg \
  && curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add -  \
- && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
+ && echo 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/chime/stable bionic universe' >> /etc/apt/sources.list \
  && apt-get update
 
 RUN apt-get install -y -q python3-sawtooth-sdk

--- a/rest_api/Dockerfile
+++ b/rest_api/Dockerfile
@@ -13,16 +13,16 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 
-FROM ubuntu:16.04
+FROM ubuntu:bionic
 
 RUN \
  apt-get update \
  && apt-get install -y -q curl gnupg \
  && curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add -  \
- && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
+ && echo 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/chime/stable bionic universe' >> /etc/apt/sources.list \
  && apt-get update
 
-RUN apt-get install -y --allow-unauthenticated -q python3-grpcio-tools=1.1.3-1 \
+RUN apt-get install -y --allow-unauthenticated -q python3-grpcio-tools \
     python3-pip \
     python3-sawtooth-rest-api \
     python3-sawtooth-sdk

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -13,13 +13,13 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN \
  apt-get update \
  && apt-get install -y -q curl gnupg \
  && curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add -  \
- && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
+ && echo 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/chime/stable bionic universe' >> /etc/apt/sources.list \
  && apt-get update
 
 RUN apt-get install -y --allow-unauthenticated -q \
@@ -30,7 +30,7 @@ RUN apt-get install -y --allow-unauthenticated -q \
     python3-sawtooth-rest-api
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
-    && apt-get install -y nodejs
+    && apt-get install -y nodejs npm
 
 RUN pip3 install \
     aiohttp \

--- a/subscriber/Dockerfile
+++ b/subscriber/Dockerfile
@@ -16,8 +16,7 @@
 FROM ubuntu:bionic
 
 RUN \
- echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD" \
- && apt-get update \
+ apt-get update \
  && apt-get install -y -q curl gnupg \
  && curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add -  \
  && echo 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/chime/stable bionic universe' >> /etc/apt/sources.list \

--- a/subscriber/Dockerfile
+++ b/subscriber/Dockerfile
@@ -13,14 +13,14 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 
-FROM ubuntu:16.04
+FROM ubuntu:bionic
 
 RUN \
  echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD" \
  && apt-get update \
  && apt-get install -y -q curl gnupg \
  && curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add -  \
- && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
+ && echo 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/chime/stable bionic universe' >> /etc/apt/sources.list \
  && apt-get update
 
 RUN apt-get install -y --allow-unauthenticated -q \


### PR DESCRIPTION
* Change to Bionic (Ubuntu 18 LTS) repo
* Use 1.2 instead of 1.0 Docker Sawtooth images
* Add package npm, split off from nodejs package in Bionic
* Remove python3-grpcio-tools old restriction to version 1.1.3-1,
  which is not on Bionic
* Add Devmode consensus container

Signed-off-by: danintel <daniel.anderson@intel.com>