### PR TITLE
Add CODEOWNERS and MAINTAINERS.md Files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @agunde406 @chenette @cianx @danintel @dcmiddle @dplumb94 @jsmitchell @ltseeley @peterschwarz @rberg2 @rbuysse @TomBarnes @vaporos

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @chenette @cianx @danintel @dcmiddle @dplumb94 @jsmitchell @ltseeley @peterschwarz @rberg2 @rbuysse @TomBarnes @vaporos
+*       @agunde406 @chenette @danintel @dcmiddle @dplumb94 @jsmitchell @peterschwarz @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,12 @@
+## Maintainers
+
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Andi Gunderson | agunde406 | agunde |
+| Anne Chenette | chenette | achenette |
+| Dan Anderson | danintel | danintel |
+| Dan Middleton | dcmiddle | Dan |
+| Darian Plumb | dplumb94 | dplumb |
+| James Mitchell | jsmitchell | jsmitchell |
+| Peter Schwarz | peterschwarz | pschwarz |
+| Shawn Amundson | vaporos | amundson |


### PR DESCRIPTION
Initial list is Sawtooth core:
https://github.com/hyperledger/sawtooth-rfcs/blob/master/subteams/core.md
Plus those with multiple commits:
https://github.com/danintel/education-sawtooth-simple-supply/graphs/contributors

Signed-off-by: danintel <daniel.anderson@intel.com>