### PR TITLE
Fix Genesis Block Creation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -126,7 +126,11 @@ services:
           sawadm keygen
           sawtooth keygen my_key
           sawset genesis -k /root/.sawtooth/keys/my_key.priv
-          sawadm genesis config-genesis.batch
+          sawset proposal create -k /root/.sawtooth/keys/my_key.priv \
+            sawtooth.consensus.algorithm.name=Devmode \
+            sawtooth.consensus.algorithm.version=0.1 \
+            -o config.batch
+          sawadm genesis config-genesis.batch config.batch
         fi;
         sawtooth-validator -vv \
           --endpoint tcp://validator:8800 \


### PR DESCRIPTION
Sawtooth 1.2.3 apparently now requires the consensus algorithm and mode
to be specified. The message showing the regression is:

```
Error: The following setting(s) are required at genesis,
but were not included in the genesis batches:
['sawtooth.consensus.algorithm.name', 'sawtooth.consensus.algorithm.version']
```

Signed-off-by: danintel <daniel.anderson@intel.com>